### PR TITLE
Autobump to latest version and automerge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,62 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /http2/go-grpc
+    schedule:
+      interval: "daily"
+      time: "06:00"
+      timezone: "Europe/Berlin"
+  - package-ecosystem: gomod
+    directory: /http2/go-http2
+    schedule:
+      interval: "daily"
+      time: "06:00"
+      timezone: "Europe/Berlin"
+  - package-ecosystem: gradle
+    directory: /http2/java-grpc
+    schedule:
+      interval: "daily"
+      time: "08:00"
+      timezone: "Europe/Berlin"
+  - package-ecosystem: gradle
+    directory: /http2/java-http2
+    schedule:
+      interval: "daily"
+      time: "08:00"
+      timezone: "Europe/Berlin"
+  - package-ecosystem: npm
+    directory: /http2/node-grpc
+    schedule:
+      interval: "daily"
+      time: "10:00"
+      timezone: "Europe/Berlin"
+  - package-ecosystem: npm
+    directory: /http2/node-http2
+    schedule:
+      interval: "daily"
+      time: "10:00"
+      timezone: "Europe/Berlin"
+  - package-ecosystem: pip
+    directory: /http2/python-grpc
+    schedule:
+      interval: "daily"
+      time: "12:00"
+      timezone: "Europe/Berlin"
+  - package-ecosystem: pip
+    directory: /http2/python-http2
+    schedule:
+      interval: "daily"
+      time: "12:00"
+      timezone: "Europe/Berlin"
+  - package-ecosystem: bundler
+    directory: /http2/ruby-grpc
+    schedule:
+      interval: "daily"
+      time: "14:00"
+      timezone: "Europe/Berlin"
+  - package-ecosystem: bundler
+    directory: /http2/ruby-http2
+    schedule:
+      interval: "daily"
+      time: "14:00"
+      timezone: "Europe/Berlin"

--- a/.github/workflows/test-sample-apps.yml
+++ b/.github/workflows/test-sample-apps.yml
@@ -1,4 +1,4 @@
-name: TEST
+name: Sample apps test and update
 
 on:
   push:
@@ -6,6 +6,10 @@ on:
   pull_request_target:
     branches: [ main ]
     types: [ opened, synchronize, reopened ]
+
+permissions:
+  pull-requests: write
+  contents: write
 
 jobs:
   sample-app-test:
@@ -75,3 +79,16 @@ jobs:
               echo "Deleting app: $app_name"
               cf8 delete "$app_name" -r -f
           done
+  automerge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    needs: [sample-app-test]
+    steps:
+      - name: Approve
+        run: gh pr review "${{ github.event.pull_request.html_url }}" --approve --body "Auto-approving dependency bump."
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge
+        run: gh pr merge "${{ github.event.pull_request.html_url }}" --auto --rebase
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
As routing-sample repo owner,
we want to ship up-to-date software without manual efforts,
So that we mitigate efforts and provide secure examples.