### PR TITLE
Use Random Routes in Test Applications

### DIFF
--- a/.github/workflows/test-sample-apps.yml
+++ b/.github/workflows/test-sample-apps.yml
@@ -56,6 +56,8 @@ jobs:
           cf8 --version
       - name: Build Java apps
         run: ./http2/gradlew clean build -p http2
+      - name: Remove routes from manifest
+        run: yq 'del(.applications[].routes)' -i "${GITHUB_WORKSPACE}/http2/apps-manifest.yml"
       - name: Logging into target CloudFoundry
         run: cf8 login -a "${{ secrets.CF_API }}" -u "${{ secrets.CF_USERNAME }}" -p "${{ secrets.CF_PASSWORD }}" -o "${{ secrets.CF_ORG }}" -s "${{ secrets.CF_SPACE }}" --origin uaa
       - name: Deploy CloudFoundry sample apps
@@ -64,15 +66,27 @@ jobs:
         run: |
           echo "### Testing HTTP2_APP app ###"
           yq e '.applications.[].name' "${GITHUB_WORKSPACE}/http2/apps-manifest.yml" | grep -i 'http2' | while read -r HTTP2_APP; do
-              echo "curl -v --http2-prior-knowledge -H 'Connection: close' 'https://$HTTP2_APP.${{ secrets.CF_DOMAIN }}'"
-              curl -v --http2-prior-knowledge -H "Connection: close" "https://$HTTP2_APP.${{ secrets.CF_DOMAIN }}"
+              ROUTE=${{ github.run_id }}-$HTTP2_APP
+              cf8 map-route $HTTP2_APP ${{ secrets.CF_DOMAIN }} --hostname $ROUTE --app-protocol http2
+              echo "curl -v --http2-prior-knowledge -H 'Connection: close' 'https://$ROUTE.${{ secrets.CF_DOMAIN }}'"
+              curl -v --http2-prior-knowledge -H "Connection: close" "https://$ROUTE.${{ secrets.CF_DOMAIN }}"
           done
           echo "Testing GRPC apps"
-          grpcurl go-grpc-test.${{ secrets.CF_DOMAIN }}:443 example.Example.Run
-          grpcurl -proto http2/java-grpc/app/src/main/proto/example.proto java-grpc-test.${{ secrets.CF_DOMAIN }}:443 example.Example.Run 
-          grpcurl -proto http2/node-grpc/example.proto node-grpc-test.${{ secrets.CF_DOMAIN }}:443 Example.Run 
-          grpcurl -proto http2/python-grpc/example.proto python-grpc-test.${{ secrets.CF_DOMAIN }}:443 Example.Run
-          grpcurl -proto http2/ruby-grpc/example.proto ruby-grpc-test.${{ secrets.CF_DOMAIN }}:443 Example.Run
+          ROUTE=${{ github.run_id }}-go-grpc-test
+          cf8 map-route go-grpc-test ${{ secrets.CF_DOMAIN }} --hostname $ROUTE --app-protocol http2
+          grpcurl $ROUTE.${{ secrets.CF_DOMAIN }}:443 example.Example.Run
+          ROUTE=${{ github.run_id }}-java-grpc-test
+          cf8 map-route java-grpc-test ${{ secrets.CF_DOMAIN }} --hostname $ROUTE --app-protocol http2
+          grpcurl -proto http2/java-grpc/app/src/main/proto/example.proto $ROUTE.${{ secrets.CF_DOMAIN }}:443 example.Example.Run 
+          ROUTE=${{ github.run_id }}-node-grpc-test
+          cf8 map-route node-grpc-test ${{ secrets.CF_DOMAIN }} --hostname $ROUTE --app-protocol http2
+          grpcurl -proto http2/node-grpc/example.proto $ROUTE.${{ secrets.CF_DOMAIN }}:443 Example.Run 
+          ROUTE=${{ github.run_id }}-python-grpc-test
+          cf8 map-route python-grpc-test ${{ secrets.CF_DOMAIN }} --hostname $ROUTE --app-protocol http2
+          grpcurl -proto http2/python-grpc/example.proto $ROUTE.${{ secrets.CF_DOMAIN }}:443 Example.Run
+          ROUTE=${{ github.run_id }}-ruby-grpc-test
+          cf8 map-route ruby-grpc-test ${{ secrets.CF_DOMAIN }} --hostname $ROUTE --app-protocol http2
+          grpcurl -proto http2/ruby-grpc/example.proto $ROUTE.${{ secrets.CF_DOMAIN }}:443 Example.Run
       - name: Clean-up
         if: success() || failure()
         run: |

--- a/.github/workflows/test-sample-apps.yml
+++ b/.github/workflows/test-sample-apps.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     concurrency: test-landscape
     environment: cf_env
+    env:
+      HOSTNAME_PREFIX: gh-run-${{ github.run_id }}-
     steps:
       - name: Limit access
         if: |
@@ -56,37 +58,25 @@ jobs:
           cf8 --version
       - name: Build Java apps
         run: ./http2/gradlew clean build -p http2
-      - name: Remove routes from manifest
-        run: yq 'del(.applications[].routes)' -i "${GITHUB_WORKSPACE}/http2/apps-manifest.yml"
       - name: Logging into target CloudFoundry
         run: cf8 login -a "${{ secrets.CF_API }}" -u "${{ secrets.CF_USERNAME }}" -p "${{ secrets.CF_PASSWORD }}" -o "${{ secrets.CF_ORG }}" -s "${{ secrets.CF_SPACE }}" --origin uaa
       - name: Deploy CloudFoundry sample apps
-        run: cf8 push -f "${GITHUB_WORKSPACE}/http2/apps-manifest.yml" --var domain=${{ secrets.CF_DOMAIN }} --vars-file "${GITHUB_WORKSPACE}/http2/gradle.properties"
+        run: cf8 push -f "${GITHUB_WORKSPACE}/http2/apps-manifest.yml" --var domain=${{ secrets.CF_DOMAIN }} --VAR hostname_prefix="$HOSTNAME_PREFIX" --vars-file "${GITHUB_WORKSPACE}/http2/gradle.properties"
       - name: Test Sample apps
         run: |
+          get_route() {
+            echo "${HOSTNAME_PREFIX}${1}.${{ secrets.CF_DOMAIN }}"
+          }
           echo "### Testing HTTP2_APP app ###"
           yq e '.applications.[].name' "${GITHUB_WORKSPACE}/http2/apps-manifest.yml" | grep -i 'http2' | while read -r HTTP2_APP; do
-              ROUTE=${{ github.run_id }}-$HTTP2_APP
-              cf8 map-route $HTTP2_APP ${{ secrets.CF_DOMAIN }} --hostname $ROUTE --app-protocol http2
-              echo "curl -v --http2-prior-knowledge -H 'Connection: close' 'https://$ROUTE.${{ secrets.CF_DOMAIN }}'"
-              curl -v --http2-prior-knowledge -H "Connection: close" "https://$ROUTE.${{ secrets.CF_DOMAIN }}"
+              curl -v --http2-prior-knowledge -H 'Connection: close' "https://$(get_route "$HTTP2_APP")"
           done
           echo "Testing GRPC apps"
-          ROUTE=${{ github.run_id }}-go-grpc-test
-          cf8 map-route go-grpc-test ${{ secrets.CF_DOMAIN }} --hostname $ROUTE --app-protocol http2
-          grpcurl $ROUTE.${{ secrets.CF_DOMAIN }}:443 example.Example.Run
-          ROUTE=${{ github.run_id }}-java-grpc-test
-          cf8 map-route java-grpc-test ${{ secrets.CF_DOMAIN }} --hostname $ROUTE --app-protocol http2
-          grpcurl -proto http2/java-grpc/app/src/main/proto/example.proto $ROUTE.${{ secrets.CF_DOMAIN }}:443 example.Example.Run 
-          ROUTE=${{ github.run_id }}-node-grpc-test
-          cf8 map-route node-grpc-test ${{ secrets.CF_DOMAIN }} --hostname $ROUTE --app-protocol http2
-          grpcurl -proto http2/node-grpc/example.proto $ROUTE.${{ secrets.CF_DOMAIN }}:443 Example.Run 
-          ROUTE=${{ github.run_id }}-python-grpc-test
-          cf8 map-route python-grpc-test ${{ secrets.CF_DOMAIN }} --hostname $ROUTE --app-protocol http2
-          grpcurl -proto http2/python-grpc/example.proto $ROUTE.${{ secrets.CF_DOMAIN }}:443 Example.Run
-          ROUTE=${{ github.run_id }}-ruby-grpc-test
-          cf8 map-route ruby-grpc-test ${{ secrets.CF_DOMAIN }} --hostname $ROUTE --app-protocol http2
-          grpcurl -proto http2/ruby-grpc/example.proto $ROUTE.${{ secrets.CF_DOMAIN }}:443 Example.Run
+          grpcurl $(get_route go-grpc-test):443 example.Example.Run
+          grpcurl -proto http2/java-grpc/app/src/main/proto/example.proto $(get_route java-grpc-test):443 Example.Run
+          grpcurl -proto http2/node-grpc/example.proto $(get_route node-grpc-test):443 Example.Run
+          grpcurl -proto http2/python-grpc/example.proto $(get_route python-grpc-test):443 Example.Run
+          grpcurl -proto http2/ruby-grpc/example.proto $(get_route ruby-grpc-test):443 Example.Run
       - name: Clean-up
         if: success() || failure()
         run: |

--- a/http2/apps-manifest.yml
+++ b/http2/apps-manifest.yml
@@ -25,7 +25,7 @@ applications:
     buildpacks:
       - go_buildpack
     routes:
-      - route: go-grpc-test.((domain))
+      - route: ((hostname_prefix))go-grpc-test.((domain))
         protocol: http2
   - name: go-http2-test
     <<: *stack
@@ -34,7 +34,7 @@ applications:
     buildpacks:
       - go_buildpack
     routes:
-      - route: go-http2-test.((domain))
+      - route: ((hostname_prefix))go-http2-test.((domain))
         protocol: http2
   - name: java-grpc-test
     <<: *stack
@@ -43,7 +43,7 @@ applications:
     buildpacks:
       - java_buildpack
     routes:
-      - route: java-grpc-test.((domain))
+      - route: ((hostname_prefix))java-grpc-test.((domain))
         protocol: http2
     env:
       JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 11.+ }}'
@@ -54,7 +54,7 @@ applications:
     buildpacks:
       - java_buildpack
     routes:
-      - route: java-http2-test.((domain))
+      - route: ((hostname_prefix))java-http2-test.((domain))
         protocol: http2
     env:
       JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 11.+ }}'
@@ -65,7 +65,7 @@ applications:
     buildpacks:
       - https://github.com/cloudfoundry/nodejs-buildpack
     routes:
-      - route: node-grpc-test.((domain))
+      - route: ((hostname_prefix))node-grpc-test.((domain))
         protocol: http2
   - name: node-http2-test
     <<: *stack
@@ -74,7 +74,7 @@ applications:
     buildpacks:
       - https://github.com/cloudfoundry/nodejs-buildpack
     routes:
-      - route: node-http2-test.((domain))
+      - route: ((hostname_prefix))node-http2-test.((domain))
         protocol: http2
   - name: python-grpc-test
     <<: *stack
@@ -83,7 +83,7 @@ applications:
     buildpacks:
       - https://github.com/cloudfoundry/python-buildpack
     routes:
-      - route: python-grpc-test.((domain))
+      - route: ((hostname_prefix))python-grpc-test.((domain))
         protocol: http2
   - name: python-http2-test
     <<: *stack
@@ -92,7 +92,7 @@ applications:
     buildpacks:
       - https://github.com/cloudfoundry/python-buildpack
     routes:
-      - route: python-http2-test.((domain))
+      - route: ((hostname_prefix))python-http2-test.((domain))
         protocol: http2
   - name: ruby-grpc-test
     <<: *stack
@@ -101,7 +101,7 @@ applications:
     buildpacks:
       - https://github.com/cloudfoundry/ruby-buildpack
     routes:
-      - route: ruby-grpc-test.((domain))
+      - route: ((hostname_prefix))ruby-grpc-test.((domain))
         protocol: http2
   - name: ruby-http2-test
     <<: *stack
@@ -110,5 +110,5 @@ applications:
     buildpacks:
       - https://github.com/cloudfoundry/ruby-buildpack
     routes:
-      - route: ruby-http2-test.((domain))
+      - route: ((hostname_prefix))ruby-http2-test.((domain))
         protocol: http2

--- a/http2/vars.yml
+++ b/http2/vars.yml
@@ -1,2 +1,2 @@
 domain: <domain.for.app.routes>
-
+hostname_prefix: test-

--- a/http2/vars.yml
+++ b/http2/vars.yml
@@ -1,2 +1,2 @@
 domain: <domain.for.app.routes>
-hostname_prefix: test-
+hostname_prefix: ""


### PR DESCRIPTION
The `sample-app-test` workflow currently fails, because someone else deployed these sample apps in his/her own CF space on the same instance. Thus, the routes are takes and cannot be reassigned to apps in our CF space.

With this change, we prefix the routes with the Workflow Run ID, which should always give us unique routes.  

Side note 1: `cf push` comes with the optional `--no-route` flag, unfortunately it's not working with mta deployments. That's why we have the yq step to remove all `routes` from the manifest before deploying it.

Side note 2: We cannot use `random-route: true` in the manifest: The GRPC tests require http2, and unfortunately the protocol for random routes defaults to `http1` and cannot be overwritten (unless using `cf update-destination`). Hence, `random-route` is not an option, as it would break the scenario where a user deploys the test apps.