### PR TITLE
Bump protobuf version for Java gRPC sample app

### DIFF
--- a/http2/java-grpc/app/build.gradle
+++ b/http2/java-grpc/app/build.gradle
@@ -19,7 +19,7 @@ repositories {
 }
 
 def grpcVersion = '1.73.0' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.17.2'
+def protobufVersion = '3.25.8'
 def protocVersion = protobufVersion
 
 dependencies {


### PR DESCRIPTION
The current protobuf version for the sample Java gRPC project results in using a protoc that is not available for macOS with Apple Silicon chips. Example errors before updating the version:
```bash
I508638@HFJF72M9TP http2 % ./gradlew clean build

> Task :java-grpc:app:generateProto FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':java-grpc:app:generateProto'.
> Could not resolve all files for configuration ':java-grpc:app:protobufToolsLocator_protoc'.
   > Could not find protoc-3.17.2-osx-aarch_64.exe (com.google.protobuf:protoc:3.17.2).
     Searched in the following locations:
         https://repo.maven.apache.org/maven2/com/google/protobuf/protoc/3.17.2/protoc-3.17.2-osx-aarch_64.exe

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.
```

After upgrading the version to the latest supported for this major release - 
```bash
I508638@HFJF72M9TP http2 % ./gradlew clean build        


BUILD SUCCESSFUL in 3s
18 actionable tasks: 18 executed
```
As you can see, there is no pre-built binary for the ARM64 architecture - https://repo.maven.apache.org/maven2/com/google/protobuf/protoc/3.17.2/.