### PR TITLE
Update documentation, Fix CI

### DIFF
--- a/.github/workflows/test-sample-apps.yml
+++ b/.github/workflows/test-sample-apps.yml
@@ -81,6 +81,7 @@ jobs:
       - name: Test IP Allow-List Sample App
         run: |
           echo "Test IPv4 is accessible"
+          sleep 10
           test "$(curl --silent --output /dev/null --write-out "%{http_code}" -4 "https://ok-${HOSTNAME_PREFIX}.cfapps.eu12.hana.ondemand.com")" -eq 200
       - name: Clean-up
         if: success() || failure()

--- a/.github/workflows/test-sample-apps.yml
+++ b/.github/workflows/test-sample-apps.yml
@@ -56,7 +56,7 @@ jobs:
         run: ./http2/gradlew clean build -p http2
       - name: Logging into target CloudFoundry
         run: cf8 login -a "${{ secrets.CF_API }}" -u "${{ secrets.CF_USERNAME }}" -p "${{ secrets.CF_PASSWORD }}" -o "${{ secrets.CF_ORG }}" -s "${{ secrets.CF_SPACE }}" --origin uaa
-      - name: Deploy CloudFoundry sample apps
+      - name: Deploy HTTP/2 sample apps
         run: cf8 push -f "${GITHUB_WORKSPACE}/http2/apps-manifest.yml" --var domain=${{ secrets.CF_DOMAIN }} --var hostname_prefix="$HOSTNAME_PREFIX" --vars-file "${GITHUB_WORKSPACE}/http2/gradle.properties"
       - name: Test HTTP/2 Sample apps
         run: |
@@ -80,7 +80,7 @@ jobs:
           cf8 bind-route-service "${{ secrets.CF_DOMAIN }}" --hostname "ok-${HOSTNAME_PREFIX}" "allow-list-${HOSTNAME_PREFIX}"
       - name: Test IP Allow-List Sample App
         run: |
-          echo "Test IPv4 is accesible"
+          echo "Test IPv4 is accessible"
           test "$(curl --silent --output /dev/null --write-out "%{http_code}" -4 "https://ok-${HOSTNAME_PREFIX}.cfapps.eu12.hana.ondemand.com")" -eq 200
       - name: Clean-up
         if: success() || failure()

--- a/.github/workflows/test-sample-apps.yml
+++ b/.github/workflows/test-sample-apps.yml
@@ -75,14 +75,13 @@ jobs:
           grpcurl -proto http2/ruby-grpc/example.proto $(get_route ruby-grpc-test):443 Example.Run
       - name: Deploy IP Allow-List Sample App
         run: |
-          cf8 push --var "domain=${{ secrets.CF_DOMAIN }}" --var "suffix=${HOSTNAME_PREFIX}" --manifest "${GITHUB_WORKSPACE}/ip-allow-listing-route-service/manifest.yml"
-          cf8 create-user-provided-service "allow-list-${HOSTNAME_PREFIX}" -r "https://ip-allow-list-rs-${HOSTNAME_PREFIX}.${{ secrets.CF_DOMAIN }}"
-          cf8 bind-route-service "${{ secrets.CF_DOMAIN }}" --hostname "ok-${HOSTNAME_PREFIX}" "allow-list-${HOSTNAME_PREFIX}"
+          cf8 push --var "domain=${{ secrets.CF_DOMAIN }}" --var "prefix=${HOSTNAME_PREFIX}" --manifest "${GITHUB_WORKSPACE}/ip-allow-listing-route-service/manifest.yml"
+          cf8 create-user-provided-service "${HOSTNAME_PREFIX}allow-list" -r "https://${HOSTNAME_PREFIX}ip-allow-list-rs.${{ secrets.CF_DOMAIN }}"
+          cf8 bind-route-service "${{ secrets.CF_DOMAIN }}" --hostname "${HOSTNAME_PREFIX}ok" "${HOSTNAME_PREFIX}allow-list"
       - name: Test IP Allow-List Sample App
         run: |
           echo "Test IPv4 is accessible"
-          sleep 10
-          test "$(curl --silent --output /dev/null --write-out "%{http_code}" -4 "https://ok-${HOSTNAME_PREFIX}.cfapps.eu12.hana.ondemand.com")" -eq 200
+          test "$(curl --silent --output /dev/null --write-out "%{http_code}" -4 "https://${HOSTNAME_PREFIX}ok.${{ secrets.CF_DOMAIN }}")" -eq 200
       - name: Clean-up
         if: success() || failure()
         run: |

--- a/README.md
+++ b/README.md
@@ -13,17 +13,21 @@ In order to leverage more advance features of the routing stack of the Cloud Fou
 The following samples are available in the respective subdirectories:
 
 * [`http2`](http2/README.md) - HTTP/2 and gRPC enabled server samples for Cloud Foundry
+* [`ip-allow-listing-route-service`](ip-allow-listing-route-service/README.md) - A route service that allows you to restrict access to your applications based on the client IP address
+* [`per-route/loadbalancing`](per-route/loadbalancing/README.md) - A sample app that demonstrates how to use customizable load balancing algorithms in Cloud Foundry
 
 ## Requirements
 
 The samples provided in this repository are intended to run in a Cloud Foundry environment. Each of the samples may contain further information on specific technical requirements.
 
 Samples are provided in the following programming languages and require the respective runtime environment for development:
+
 * go
 * java
 * node
 * python
 * ruby
+
 ## Download and Installation
 
 These samples are provided as source code and should be seen as starting point or reference on how to approach or solve a particular requirement.
@@ -32,18 +36,22 @@ The download from GitHub, either via Git or archive, is recommended.
 
 ## Known Issues
 
-- HTTP/2 support is being rolled out globally but is not complete. In order to use the HTTP/2 samples, you need to enable a custom domain with HTTP/2 support.
-  <!-- todo link to the blog post about that! -->
+- HTTP/2 support is being rolled out globally but is not complete. In order to use the HTTP/2 samples, you need to enable a custom domain with HTTP/2 support. See our blog post [HTTP/2 on the SAP BTP, Cloud Foundry runtime](https://blogs.sap.com/2022/02/16/http-2-on-sap-btp-cloud-foundry-runtime/) for more information.
 
 ## How to obtain support
+
 [Create an issue](https://github.com/SAP-samples/cf-routing-samples/issues) in this repository if you find a bug or have questions about the content.
 
 For additional support, [ask a question in SAP Community](https://answers.sap.com/questions/ask.html).
 
 ## Contributing
+
 If you want to contribute, please check the [CONTRIBUTING.md](CONTRIBUTING.md) documentation for contribution guidelines.
+
 ## Code of conduct
 
 SAP adopts the Contributor's Covenant 2.0 across our open source projects to ensure a welcoming and open culture for everyone involved ([Code of Conduct](CODE_OF_CONDUCT.md)).
+
 ## License
+
 Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This project is licensed under the Apache Software License, version 2.0 except as noted otherwise in the [LICENSE](LICENSES/Apache-2.0.txt) file.

--- a/ip-allow-listing-route-service/README.md
+++ b/ip-allow-listing-route-service/README.md
@@ -29,15 +29,15 @@ Put this file into the app directory next to the manifest file and name it `allo
 can push the application like this (you may need to adjust the domain depending on the region):
 
 ```
-cf push -f ./manifest.yml --var domain=cfapps.example.com --var suffix=foo
+cf push -f ./manifest.yml --var domain=cfapps.example.com --var prefix=foo
 ```
 
-This pushes the app and makes it available at `ip-allow-list-rs-foo.cfapps.example.com`.
+This pushes the app and makes it available at `foo-ip-allow-list-rs.cfapps.example.com`.
 Now we can turn it into a route service and bind it to an already existing route, provide the
-domain and host of the route you want restrict access to:
+domain and host of the route you want to restrict access to:
 
 ```
-cf create-user-provided-service allow-listing -r https://ip-allow-listing-rs-foo.cfapps.example.com
+cf create-user-provided-service allow-listing -r https://foo-ip-allow-listing-rs.cfapps.example.com
 cf bind-route-service cfapps.example.com --hostname my-app allow-listing
 ```
 

--- a/ip-allow-listing-route-service/manifest.yml
+++ b/ip-allow-listing-route-service/manifest.yml
@@ -7,7 +7,7 @@ applications:
   memory: 128M
   instances: 1
   routes:
-  - route: ip-allow-list-rs-((suffix)).((domain))
+  - route: ((prefix))ip-allow-list-rs.((domain))
 - name: ok
   path: ./ok
   lifecycle: cnb
@@ -16,4 +16,4 @@ applications:
   memory: 64M
   instances: 1
   routes:
-  - route: ok-((suffix)).((domain))
+  - route: ((prefix))ok.((domain))

--- a/per-route/loadbalancing/README.md
+++ b/per-route/loadbalancing/README.md
@@ -1,0 +1,11 @@
+# Customizable Load Balancing Algorithm Sample App
+
+This sample app demonstrates how to use customizable load balancing algorithms in Cloud Foundry. It allows you to define your own load balancing logic for routing requests to different application instances.
+
+You can find more information about using customizable load balancing algorithms in the following blog post:
+
+https://community.sap.com/t5/technology-blog-posts-by-sap/support-for-customizable-load-balancing-algorithms/ba-p/14128471
+
+Additional documentation on load balancing algorithms is available in the Cloud Foundry docs:
+
+https://docs.cloudfoundry.org/devguide/custom-per-route-options.html


### PR DESCRIPTION
⚠️ This PR will have to be force-merged because the CI checks are always using the (broken) master workflow file.

Successful, manually triggered run with the contents of this PR (with some [slight adjustments to provide the required PR reference](https://github.com/SAP-samples/cf-routing-samples/compare/improve-docs-fix-ci...JUST_FOR_TESTING-improve-docs-fix-ci?expand=1)): https://github.com/SAP-samples/cf-routing-samples/actions/runs/16374124160/job/46269669274

In the previous state of the IP allowlisting sample test, invalid app routes were created (subdomains that end with `-`), causing the test/curl to fail.
This PR fixes this by aligning the domain names of the IP allowlisting sample with the other scenarios:
We are now using the `$HOST_PREFIX` (which ends with the offending`-`)  as a prefix to the app-specific name, instead of using it as a suffix.

Also includes:
Improve main README.md
Fix typo in test-sample-apps.yml
Add docs for lb sample

The loadbalancing sample may have to be removed again (incomplete/no tests), this will be done in a separate PR.