### PR TITLE
fix: increase disk quotas for sample apps to avoid deployment failures

### DIFF
--- a/http2/apps-manifest.yml
+++ b/http2/apps-manifest.yml
@@ -3,19 +3,19 @@ version: 1
 stack: &stack
   stack: cflinuxfs4
 go_defaults: &go_defaults
-  disk_quota: 32M
+  disk_quota: 512M
   memory: 32M
 java_defaults: &java_defaults
-  disk_quota: 768M
+  disk_quota: 1G
   memory: 768M
 node_defaults: &node_defaults
-  disk_quota: 256M
+  disk_quota: 1G
   memory: 256M
 ruby_defaults: &ruby_defaults
-  disk_quota: 256M
+  disk_quota: 1G
   memory: 256M
 python_defaults: &python_defaults
-  disk_quota: 512M
+  disk_quota: 1G
   memory: 512M
 applications:
   - name: go-grpc-test

--- a/http2/go-grpc/app-manifest.yml
+++ b/http2/go-grpc/app-manifest.yml
@@ -3,7 +3,7 @@ applications:
   - name: go-grpc-test
     buildpacks:
       - go_buildpack
-    disk_quota: 32M
+    disk_quota: 512M
     memory: 32M
     routes:
       - route: go-grpc-test.((domain))

--- a/http2/go-http2/app-manifest.yml
+++ b/http2/go-http2/app-manifest.yml
@@ -3,7 +3,7 @@ applications:
   - name: go-http2-test
     buildpacks:
       - go_buildpack
-    disk_quota: 32M
+    disk_quota: 512M
     memory: 32M
     routes:
       - route: go-http2-test.((domain))

--- a/http2/java-grpc/app-manifest.yml
+++ b/http2/java-grpc/app-manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
   - name: java-grpc-test
-    disk_quota: 768M
+    disk_quota: 1G
     memory: 768M
     path: ./app/build/distributions/app.zip
     buildpacks:

--- a/http2/java-http2/app-manifest.yml
+++ b/http2/java-http2/app-manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
   - name: java-http2-test
-    disk_quota: 768M
+    disk_quota: 1G
     memory: 768M
     path: ./app/build/distributions/app.zip
     buildpacks:

--- a/http2/node-grpc/app-manifest.yml
+++ b/http2/node-grpc/app-manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
   - name: node-grpc-test
-    disk_quota: 256M
+    disk_quota: 1G
     memory: 256M
     buildpacks:
       - https://github.com/cloudfoundry/nodejs-buildpack

--- a/http2/node-http2/app-manifest.yml
+++ b/http2/node-http2/app-manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
   - name: node-http2-test
-    disk_quota: 256M
+    disk_quota: 1G
     memory: 256M
     buildpacks:
       - https://github.com/cloudfoundry/nodejs-buildpack

--- a/http2/python-grpc/app-manifest.yml
+++ b/http2/python-grpc/app-manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
   - name: python-grpc-test
-    disk_quota: 512M
+    disk_quota: 1G
     memory: 512M
     buildpacks:
       - https://github.com/cloudfoundry/python-buildpack

--- a/http2/python-http2/app-manifest.yml
+++ b/http2/python-http2/app-manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
   - name: python-http2-test
-    disk_quota: 512M
+    disk_quota: 1G
     memory: 512M
     buildpacks:
       - https://github.com/cloudfoundry/python-buildpack

--- a/http2/ruby-grpc/app-manifest.yml
+++ b/http2/ruby-grpc/app-manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
   - name: ruby-grpc-test
-    disk_quota: 256M
+    disk_quota: 1G
     memory: 256M
     buildpacks:
       - https://github.com/cloudfoundry/ruby-buildpack

--- a/http2/ruby-http2/app-manifest.yml
+++ b/http2/ruby-http2/app-manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
   - name: ruby-http2-test
-    disk_quota: 256M
+    disk_quota: 1G
     memory: 256M
     buildpacks:
       - https://github.com/cloudfoundry/ruby-buildpack

--- a/per-route/loadbalancing/manifest.yml
+++ b/per-route/loadbalancing/manifest.yml
@@ -3,7 +3,7 @@ applications:
   instances: 3
   buildpacks:
   - go_buildpack
-  disk_quota: 64M
+  disk_quota: 512M
   memory: 64M
   routes:
   - route: per-route-lb.((domain))


### PR DESCRIPTION
The current CI validation failures are due to the ruby-grpc app not having enough disk space.
I increased all disk quotas to be future proof.

From `cf logs --recent`:
```
2026-05-19T06:34:07.04+0000 [CELL/0] OUT Cell 99901a43-1e9a-4e12-840e-d8604272dd1d successfully destroyed container for instance 59f6c35a-b5f1-46f4-4f4d-ea13
   2026-05-19T06:34:08.64+0000 [CELL/0] ERR Copying droplet into the container failed: stream-in: nstar: error streaming in: exit status 2. Output: tar: ./deps/0/ruby/bin/ruby: Wrote only 3072 of 10240 bytes
   2026-05-19T06:34:08.64+0000 [CELL/0] ERR tar: ./deps/0/ruby/bin/gem: Cannot open: No space left on device
   2026-05-19T06:34:08.64+0000 [CELL/0] ERR tar: ./deps/0/ruby/bin/bundle: Cannot open: No space left on device
   2026-05-19T06:34:08.64+0000 [CELL/0] ERR tar: ./deps/0/ruby/bin/bundler: Cannot open: No space left on device
   2026-05-19T06:34:08.64+0000 [CELL/0] ERR tar: ./deps/0/ruby/bin/rdbg: Cannot open: No space left on device
   2026-05-19T06:34:08.64+0000 [CELL/0] ERR tar: ./deps/0/ruby/bin/erb: Cannot open: No space left on device
   2026-05-19T06:34:08.64+0000 [CELL/0] ERR tar: ./deps/0/ruby/bin/irb: Cannot open: No space left on device
   2026-05-19T06:34:08.64+0000 [CELL/0] ERR tar: ./deps/0/ruby/bin/racc: Cannot open: No space left on device
   2026-05-19T06:34:08.64+0000 [CELL/0] ERR tar: ./deps/0/ruby/bin/rake: Cannot open: No space left on device
   2026-05-19T06:34:08.64+0000 [CELL/0] ERR tar: ./deps/0/ruby/bin/rbs: Cannot open: No space left on device
   2026-05-19T06:34:08.64+0000 [CELL/0] ERR tar: ./deps/0/ruby/bin/rdoc: Cannot open: No space left on device
   2026-05-19T06:34:08.64+0000 [CELL/0] ERR tar: ./deps/0/ruby/bin/ri: Cannot open: No space left on device
   2026-05-19T06:34:08.64+0000 [CELL/0] ERR tar: ./deps/0/ruby/bin/syntax_suggest: Cannot open: No space left on device
   2026-05-19T06:34:14.34+0000 [CELL/0] OUT Cell 5fcf60bc-0c79-464a-9eeb-15155c28f598 stopping instance 844a0fb3-d3a0-4fa0-60a2-1aa3
   2026-05-19T06:34:14.34+0000 [CELL/0] OUT Cell 5fcf60bc-0c79-464a-9eeb-15155c28f598 destroying container for instance 844a0fb3-d3a0-4fa0-60a2-1aa3
   2026-05-19T06:34:14.36+0000 [API/0] OUT Process has crashed
```