### PR TITLE
Hash-based route definition sample

### DIFF
--- a/per-route/loadbalancing/manifest.yml
+++ b/per-route/loadbalancing/manifest.yml
@@ -13,3 +13,8 @@ applications:
   - route: per-route-lb-rr.((domain))
     options:
       loadbalancing: round-robin
+  - route: per-route-lb-hb.((domain))
+    options:
+      loadbalancing: hash
+      hash_header: http-header-name
+      hash_balance: 1.2      


### PR DESCRIPTION
Sample for a hash-based route definition in the [app manifest](https://docs.cloudfoundry.org/devguide/hash-based-routing.html#options-hash-set-manifest)

Hash-balance factor value is explained in [CF documentation](https://docs.cloudfoundry.org/devguide/hash-based-routing.html#handling-imbalance-loads)